### PR TITLE
Merge latest `clean-dump` changes

### DIFF
--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/communicationnpc_13/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/communicationnpc_13/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「あれ？　困ったことがありましたか？」=
 //「私に何か聞きたいことでもありました？　何でも聞いてください！」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/tips_00/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/tips_00/translation.txt
@@ -1,0 +1,19 @@
+//
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
+//
+//ヤマネコ >=
+//<color%3D#ffa801ff>ヤマネコ</color>を<color%3D#ffa801ff>自然公園</color>や<color%3D#ffa801ff>路地</color>でたまーに見かけるって聞くよ。見つけられたらラッキー！=
+//ヤシガニ >=
+//<color%3D#ffa801ff>浜辺</color>や<color%3D#ffa801ff>自然公園</color>には稀に<color%3D#ffa801ff>ヤシガニ</color>が出る事があるよ。立派なハサミで挟まれないように注意！=
+//ロマンチックな告白は…… >=
+//<color%3D#ffa801ff>流れ星が綺麗に見える</color>ような静かな場所で愛の<color%3D#ffa801ff>告白</color>……ロマンチックな告白に憧れる～！=
+//もう一つのビーチ？ >=
+//この島には立ち入り禁止になってる<color%3D#ffa801ff>もう一つのビーチ</color>があるんだよ。今はどうなってるかなぁ～？=
+//ウムイの鐘 >=
+//<color%3D#ffa801ff>灯台</color>の近くに<color%3D#ffa801ff>ウムイの鐘</color>がおいてあるよ。<color%3D#ffa801ff>恋人同士</color>でその鐘を鳴らすと、その二人は必ず結ばれるっていう噂があるんだ～。=
+//カップルドリンク >=
+//<color%3D#ffa801ff>ホテルのプールサイド</color>で注文できる<color%3D#ffa801ff>トロピカルドリンク</color>が人気だよ。<color%3D#ffa801ff>恋人同士</color>で一緒に飲むのがブームみたい。=
+//デートスポット >=
+//この島には<color%3D#ffa801ff>カップル</color>で楽しめる<color%3D#ffa801ff>スポット</color>がいくつかあるんだよ。そういう相手がいるなら一緒に周ってみてね！=
+//バナナボート >=
+//<color%3D#ffa801ff>浜辺のレンタルショップ</color>で頼めば<color%3D#ffa801ff>バナナボート</color>を体験できるよ。よかったら<color%3D#ffa801ff>恋人同士</color>で一緒に体験してみてね！=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_05/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_05/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>に興味ある？」=
 //「深海魚を釣ってみたいんだけど、難しいみたい」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_10/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_10/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「汝はこの島で<color%3Dyellow>釣り</color>をやったことはあるか？」=
 //「あれは楽しいな！　待っている間は設定を考え……ああ、いや何も言ってないぞ！　とにかく、我ははまったかもしれない」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_17/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_17/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>って割と好きなのよね」=
 //「魚との駆け引きが、意外とのめり込むのよ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_18/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_18/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>って、楽しいと思いませんか？」=
 //「のんびり糸を垂らしているだけなら、何の事故も起きなくて安全ですからね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_19/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_19/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>って楽しいよね」=
 //「釣りあげた時の手ごたえもいいし、のんびり待ってるのも楽しいよ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_20/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_20/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>って……楽しいですよね」=
 //「釣り糸をのんびり垂らしてるだけで……釣りしてるぞって気分になれるんです」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_23/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_23/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>は、楽しいですな」=
 //「釣りマンガとかも読んでるから、意外とすんなり楽しめるんだなぁ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_25/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_25/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「私、<color%3Dyellow>釣り</color>って結構いいと思うんだよね～」=
 //「釣り糸を垂らしてるだけで、釣り人気分になれるっすからね～」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_26/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_26/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>、する？　面白いよ……？」=
 //「うん……二人で一緒に大物釣りたい……」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_32/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistena_32/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「あなたは本格的な<color%3Dyellow>釣り</color>をしたことがありますか？」=
 //「趣味の釣りとはやはり次元が違いますね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_03/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_03/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>ツリーイング</color>に興味があったりするですか？」=
 //「あんな風に樹の上で楽しめるなんて、テンション上がっちゃうですよね！」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_07/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_07/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「お前は<color%3Dyellow>ツリーイング</color>をやったことあるか？」=
 //「小さい頃に夢見た木登り体験が出来て、すっげー楽しかったぜ！」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_09/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_09/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「あんたはもう<color%3Dyellow>ツリーイング</color>はやってみた？」=
 //「猿みたいに自由に……とまではいかないけど、木の上で遊べて楽しいわよね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_12/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_12/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「おまえは、<color%3Dyellow>ツリーイング</color>に興味あるか？」=
 //「もうチェック済みとはさすがだ！　あんな風に樹の上で楽しめるなんていいよなー」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_13/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_13/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>ツリーイング</color>って、結構面白いよね？」=
 //「アタシ、アレ好きだよー。高い所に登るのって楽しいよね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_14/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_14/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>ツリーイング</color>って面白いよな」=
 //「それいいな。私、木登りとか結構好きなんだよ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_15/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_15/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>ツリーイング</color>って、最高に面白いぞー」=
 //「木登りって全身使うから、面白いんだぞ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_30/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_30/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>ツリーイング</color>、とても楽しいわよ？」=
 //「あの自然を普段見られない視点て見るのがとても気持ちいいのよ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_31/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_31/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「おまえは、<color%3Dyellow>ツリーイング</color>をやってみたことはあるか？」=
 //「ああやって木に登れるのは楽しいよな。柄にもなく童心に帰って楽しんだよ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_34/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenb_34/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「アナタは<color%3Dyellow>Ｔｒｅｅｉｎｇ</color>知ってマス？」=
 //「Ｙｅｓ！　高いところ登る、気持ちいデス！」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_00/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_00/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>シュノーケリング</color>って、面白いのよ」=
 //「熱帯魚を間近でみることが出来るから、何度もやってみたくなるのよね～」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_02/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_02/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「間近で魚を見れる<color%3Dyellow>シュノーケリング</color>は最高ですわね」=
 //「魚と一緒に泳げて、優雅な気分に浸れますわ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_04/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_04/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>シュノーケリング</color>に興味はある？」=
 //「近くで魚を見ることが出来て、すごく楽しいの」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_06/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_06/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「お魚を間近で見ることの出来る<color%3Dyellow>しゅのーけりんぐ</color>は、とても面白いですね」=
 //「初めて体験したのですが……幼子の様に夢中になってしまいました」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_11/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_11/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「あなたは、<color%3Dyellow>シュノーケリング</color>に興味あるかしら？」=
 //「お魚を眺めながら綺麗な海を泳げて、とてもワクワクするのよね～」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_16/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_16/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>シュノーケリング</color>ってなかなか楽しいわね」=
 //「水が綺麗だから、海の中が本当に素敵なのよ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_24/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_24/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「私、<color%3Dyellow>シュノーケリング</color>に興味があります♡」=
 //「あなたと一緒に潜れたなら、同じ海水に溶け込んだみたいで、堪らないでしょうね♡」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_33/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_33/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「ねぇ、<color%3Dyellow>シュノーケリング</color>とスキューバダイビングの違い、わかる？」=
 //「そう、あのタンクがあるかないかなのよね主に」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_37/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_37/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「あなたは<color%3Dyellow>シュノーケリング</color>に興味ありますか？」=
 //「海を堪能するには欠かせないアクティビティですね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_39/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistenc_39/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「ここの海は綺麗だから、<color%3Dyellow>シュノーケリング</color>をしないのは損よー」=
 //「海は潜る度に景色が変わるからねー。何度でも楽しめるさー」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_01/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_01/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「実は<color%3Dyellow>釣り</color>に挑戦してみたんです。とても楽しかったですよ」=
 //「ふふ、面白いですよね。私、はまってしまうかもしれません」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_08/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_08/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「あなたは、<color%3Dyellow>釣り</color>をしたことあるのかな？」=
 //「挑戦してみたんだけど、面白かったよ～。待ってる間もお友達とお話出来るから、けっこう好きになったかも」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_21/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_21/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「私、<color%3Dyellow>釣り</color>って好きなんだ」=
 //「棹と糸の感覚で魚と駆け引きする感じ、面白いよね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_22/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_22/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>って、いいよね」=
 //「魚を待ってる時のドキドキ感とか、ヒットしたときの手ごたえとか、最高だよ」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_27/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_27/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>はいいわよ？　ひたすら没頭出来るし」=
 //「ふふっ、今度、大物釣ってあんたに見せびらかすんだから」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_28/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_28/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「さて、お主に<color%3Dyellow>釣り</color>の何たるかを語ってやるとするかの？」=
 //「おぉ、お主、なかなか通じゃのう……」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_29/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_29/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>はひたすら没頭出来るのでお勧めですよ？」=
 //「それに釣りをしている最中は自分を見直す時間にも使えたりもします」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_35/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_35/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「ねぇ、<color%3Dyellow>釣り</color>するときのコツ、知っとー？」=
 //「まあ、なんかなし忍耐なんやけどね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_36/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_36/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「貴方、この島で<color%3Dyellow>釣り</color>はやってみた？」=
 //「私は初めて挑戦してみたわ。意外と楽しいものね」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_38/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_00/topiclistend_38/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.1 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「私、あまり上手ではありませんが、<color%3Dyellow>釣り</color>が好きなんです」=
 //「たまに上手に釣れた時の、手の感覚が最高なんです」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_31/communicationnpc_13/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_31/communicationnpc_13/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「あれ？　困ったことがありましたか？」=
 //「私に何か聞きたいことでもありました？　何でも聞いてください！」=

--- a/Translation/en/RedirectedResources/assets/abdata/communication/info_31/topiclistena_18/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/communication/info_31/topiclistena_18/translation.txt
@@ -1,5 +1,5 @@
 //
-// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.0
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
 //
 //「<color%3Dyellow>釣り</color>って、楽しいと思いませんか？」=
 //「のんびり糸を垂らしているだけなら、何の事故も起きなくて安全ですからね」=

--- a/Translation/en/RedirectedResources/assets/abdata/h/list/01/result_topic/translation.txt
+++ b/Translation/en/RedirectedResources/assets/abdata/h/list/01/result_topic/translation.txt
@@ -1,0 +1,14 @@
+//
+// Dumped for Koikatsu Sunshine v1.0.2 (KoikatsuSunshine) by KKS_TextDump v1.4.5.1
+//
+//キスの味=
+//初経験=
+//ぬくもり=
+//体の相性=
+//甘い夜=
+//胸の話=
+//お尻の話=
+//性器=
+//フェチ=
+//好きな体位=
+//欲求不満=


### PR DESCRIPTION
***DO NOT SQUASH MERGE***

Two new asset types dumped.  

`clean-dump` is also based of `TextDump` with the fix to encode `=`.  I already applied that fix to `master` in this case, which is why there's a handful of header only changes in here (anything with tags with a version in the header of TextDump < 1.4.5.1 is probably dumped wrong).