### PR TITLE
Communication tutorial + updated Free Roam tutorial

### DIFF
--- a/Translation/en/Text/Main/Tutorial-Communication.txt
+++ b/Translation/en/Text/Main/Tutorial-Communication.txt
@@ -1,0 +1,69 @@
+#set level -1024
+会話やスキンシップで仲良くなろう！=Get close via conversations and skinship!
+コミュニケーション：会話や一緒に行動することで好感度が変化します。= Communication: Talking/doing activities together raises a girl's affection.
+●話を振る=● Talking
+「世間話」<size%3D30>や</size>\n「コイバナ」<size%3D30>など</size>\n  話を振ると=Have\n“Small Talk”,\n“Love Talk” etc, and...
+「好感度」=Her\nAffection
+<size%3D30>が</size>上がります=\n       goes up!
+spacing to align with above text
+●スキンシップ=● Skinship
+「触る」=    Caress
+「見る」=        Stare
+//spacing shit to match picture
+スキンシップで=\nUse skinship
+女の子<size%3D36>の</size>反応=      and enjoy
+//spacing shit to align with line below
+<size%3D30>を</size>楽しもう！=her reactions!
+●コイカツ=● Koikatsu
+女の子と=Do things
+一緒<size%3D36>に</size>行動=together with a girl
+島巡り=Travel
+<size%3D24>好感度</size>「愛の絆」<size%3D24>の時</size>\n特別なデートスポット\n<size%3D24>が</size>出現<size%3D24>します。</size>=Special date spots appear if you share a “true love”
+「話題」を使い、女の子とのコミュニケーションをより楽しもう！=  Use “topics” to get more out of your conversations!
+//spacing shit
+「話題」の獲得=  Getting topics
+マップで拾ったり=From spots
+話を振ったり=  By talking
+一緒に\n行動したり\n<size%3D30>することで</size>=Doing\njoint activities
+<size%3D36>が</size>手に入る !!=are used in →
+//Ignore line with white space
+●獲得した話題を使って「聞く」、「話題を振る」=● Using topics when replying/asking
+話題のカテゴリー=Topic category
+「名物」=Specialty
+「レジャー」=   Leisure
+「自然」=Nature
+「海」=Sea
+<size%3D30>女の子から</size>振られた話題<size%3D30>に</size>=When replying to a girl
+<size%3D30>合わせたり…</size>=\nReply with a\nmatching topic
+<size%3D30>「話題を振る」から</size>\n  高レアの話題\n<size%3D30>  を使ったりして</size>= Use a rare topic\n when asking
+//spacing shit
+ヤシガニ=☆ 3
+ウミガメ=☆ 4
+//these two lines can never be aligned properly holy fuck
+※☆３以上は１度だけ！=※ ☆ 3 or more topics\ncan only be used once!
+※同カテゴリーの\n   話題でも可 !!=\n\n※ You use the same topic to reply!
+より好感度を上げよう！=To raise more affection!
+◆ステータスゲージ：女の子の現在の状態や関係を確認できます。=◆ Status bar: Display info on your relationship + the girl's current state.
+「関係性」=Relationship
+現在の関係性です。=Shows your current relationship.
+知り合い=Acquaint.
+愛の絆=True love
+「好感度ゲージ」=Affection bar
+現在の好感度を表すゲージです。最大までたまると関係が１段階進展します。=A bar representing her affection for you. Fill it up to advance to the next stage.
+「会話時間」=Conversation time bar
+会話ができる残り時間を表すゲージです。\nゲージがなくなるとコミュニケーションが終了します。\n時間帯が変わると回復します。=A bar showing how much time you've left to talk to her.\nConversations end immediately when the bar is emtpy.\nRecovers when the time period changes.
+「Ｈゲージ」=Horny bar
+女の子のＨしたい欲求です。高いほどＨの誘いが成功しやすくなります。=A bar representing her horniness. The higher it is, the easier it is to ask her for H.
+コイカツポイント=Koikatsu Point
+女の子とのコミュニケーションや、一緒に行動することで「コイカツポイント」が獲得できます。\nコイカツポイントはショップにて商品と交換することができます。=Koikatsu Point can be acquired by talking with girls and doing joint activities.\nKoikatsu Point can be exchanged for goods at the shop.
+◆Ｈをするには=◆ How to H
+「エッチしたい」=  Ask for Sex
+関係<size%3D30>を</size>深めると=Once you're close enough
+エッチ<size%3D36>に</size>誘う=\nYou can ask\nfor Sex!
+ことができます= 
+//ignoring with white space
+「自室に誘う」=  Invite to Room
+滞在中<size%3D30>の</size>自室<size%3D30>に</size>= 
+//ignore with white space
+女の子<size%3D36>を</size>\n連れ込めます=You can bring a girl to your lodging Room!
+#unset level -1024

--- a/Translation/en/Text/Main/Tutorial-Communication.txt
+++ b/Translation/en/Text/Main/Tutorial-Communication.txt
@@ -42,7 +42,7 @@ spacing to align with above text
 //these two lines can never be aligned properly holy fuck
 ※☆３以上は１度だけ！=※ ☆ 3 or more topics\ncan only be used once!
 ※同カテゴリーの\n   話題でも可 !!=\n\n※ You use the same topic to reply!
-より好感度を上げよう！=To raise more affection!
+より好感度を上げよう！=To gain more affection!
 ◆ステータスゲージ：女の子の現在の状態や関係を確認できます。=◆ Status bar: Display info on your relationship + the girl's current state.
 「関係性」=Relationship
 現在の関係性です。=Shows your current relationship.

--- a/Translation/en/Text/Main/Tutorial-FreeRoam.txt
+++ b/Translation/en/Text/Main/Tutorial-FreeRoam.txt
@@ -4,14 +4,14 @@
 ◆ゲームの流れ=◆ Game flow
 島を移動、探索しよう=Move around and explore the island
 女の子に話しかけよう=Talk to girls
-仲良くなったら・・・=Advance your relationships to...
+仲良くなったら・・・=Advance your relationships to have
 簡単操作=Controls
 <size%3D48>　　　　</size> で\n　自由<size%3D30>に</size>移動！=\nMove freely!
 　　　　話しかけて= Talk and
 \n<size%3D48>仲良くなろう！</size>=\nBecome friends!
-一緒に=Do things
-\n　<size%3D48> 行動！</size>=\n together!
-デート！=Date!
+一緒に=Joint
+\n　<size%3D48> 行動！</size>=\n activities!
+デート！=Dates!
 そして=And
 ◆マップ画面：様々な場所で過ごしている女の子たちを探して話しかけてみましょう=◆ Map: Find and talk to girls who are in various places around the island
 ●移動操作=● Movement controls
@@ -37,7 +37,7 @@
 「ショップ」= Shop
 コイカツポイントを消費して商品を購入したり、\n集めた話題を別の話題に交換できます。\nまた、プレイヤーの滞在先もここで変更できます。=You can spend Koikatsu points to buy items, or\nexchange collected topics for a new one.\nYou can also change the player's lodging here.
 「特殊デート」= Special date
-一緒に行動中の恋人の好感度が「愛の絆」の時\nに出現する、特別なデートスポットです。=A special date spot that only appears when you\nhave a lover's bond with the girl following you.
+一緒に行動中の恋人の好感度が「愛の絆」の時\nに出現する、特別なデートスポットです。=A special date spot that only appears when you\nhave a “true love” with the girl following you.
 「お祈り」= Shrine
 コイカツポイントを消費して一日に一度\nお祈りをすることができます。=You can pray once a day, consuming\nKoikatsu points in the process.
 「エステ」= Salon


### PR DESCRIPTION
Liberal use of voodoo black magic and pepega green magic were needed.
Free Roam tutorial updated because `一緒に＝ do things` was also showing up in the Communication tutorial with no way to override
Details here on Discord: https://discord.com/channels/447114928785063977/448406329862782976/894603183689724035

Images included for reference:
Updated Free Roam:
![UpdatedFreeRoam](https://user-images.githubusercontent.com/32755226/136064262-cc0b69c5-4ae3-481f-bdb2-22aae727acfc.png)
![UpdatedFreeRoam2](https://user-images.githubusercontent.com/32755226/136064280-dc83f770-276d-4470-8883-c27ae2034370.png)

Communication:
![CommunicationTutorial1](https://user-images.githubusercontent.com/32755226/136064317-129d6cae-6e92-4bb9-8c01-0f30b69e6632.png)
![CommunicationTutorial2](https://user-images.githubusercontent.com/32755226/136064329-686018ec-4cbd-49d6-8758-375a28e1aece.png)
![CommunicationTutorial3](https://user-images.githubusercontent.com/32755226/136064335-28b25a8d-fe23-4fef-b606-9564fff8e0a5.png)
![CommunicationTutorial4](https://user-images.githubusercontent.com/32755226/136064340-a03d39d8-ef1a-4f63-ad80-110634ac51e5.png)
